### PR TITLE
解析結果一覧画面を作成 #36

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,9 +13,9 @@
       <el-button @click="$router.push('minokich')">minokich</el-button>
     </div>
     <div style="margin-top:8px;">
-      <el-button @click="$router.push('analysisRequest')">解析依頼画面</el-button>
-      <el-button @click="$router.push('analysisResultList')">解析結果一覧画面</el-button>
-      <el-button @click="$router.push('analysisResult')">解析結果画面</el-button>
+      <el-button @click="$router.push({ name: 'analysisRequest' })">解析依頼画面</el-button>
+      <el-button @click="$router.push({ name: 'analysisResultList' })">解析結果一覧画面</el-button>
+      <el-button @click="$router.push({ name: 'analysisResult' })">解析結果画面</el-button>
     </div>
     <router-view></router-view>
     <!-- <HelloWorld msg="Welcome to Your Vue.js App"/> -->

--- a/src/element-variables.scss
+++ b/src/element-variables.scss
@@ -3,7 +3,8 @@ Write your variables here. All available variables can be
 found in element-ui/packages/theme-chalk/src/common/var.scss.
 For example, to overwrite the theme color:
 */
-$--color-primary: teal;
+// $--color-primary: teal;
+$--color-primary: #409EFF;
 
 /* icon font path, required */
 $--font-path: '~element-ui/lib/theme-chalk/fonts';

--- a/src/views/AnalysisResultList.vue
+++ b/src/views/AnalysisResultList.vue
@@ -1,8 +1,85 @@
 <template>
-  <div class="home">解析結果一覧画面</div>
+  <div>
+    <div class="home">解析結果一覧画面</div>
+    <el-row>
+      <el-col :span="24">
+        <div class="grid-content bg-purple-dark">
+          <div>検索ワード</div>
+             <el-input
+                 placeholder="Type something"
+                 prefix-icon="el-icon-search"
+                 v-model="search_word">
+             </el-input>
+        </div>
+      </el-col>
+    </el-row>
+    <el-row>
+      
+      <el-col :span="24">
+        <div class="grid-content bg-purple-dark">
+          <el-table
+             v-loading="loading"
+             :data="tableData"
+             stripe
+             style="width: 100%">
+             <el-table-column
+               prop="id"
+               label="ID"
+               width="180">
+             </el-table-column>
+             <el-table-column
+               prop="analysis_start_date"
+               label="検索開始日"
+               width="180">
+             </el-table-column>
+             <el-table-column
+               prop="analysis_end_date"
+               label="検索終了日"
+               width="180">
+             </el-table-column>
+             <el-table-column
+               prop="analysis_word"
+               label="検索ワード"
+               width="180">
+             </el-table-column>
+             <el-table-column
+               prop="status"
+               label="ステータス"
+               width="180">
+             </el-table-column>
+             <el-table-column
+               prop="favorite_count"
+               label="いいね数">
+             </el-table-column>
+             <el-table-column
+               prop="user_count"
+               label="ユーザ数">
+             </el-table-column>
+             <el-table-column
+               prop="tweet_count"
+               label="ツイート総数">
+             </el-table-column>
+
+
+           </el-table>
+        </div>
+      </el-col>
+
+      <el-col :span="24">
+        <el-pagination
+          @current-change="handleSizeChange"
+          background
+          layout="prev, pager, next"
+          :total="total_data">
+        </el-pagination>
+      </el-col>
+    </el-row>
+  </div>
 </template>
 
 <script lang="ts">
+import Vue from 'vue';
+import axios from 'axios';
 import { Component, Vue } from 'vue-property-decorator';
 import HelloWorld from '@/components/HelloWorld.vue'; // @ is an alias to /src
 
@@ -11,11 +88,89 @@ import HelloWorld from '@/components/HelloWorld.vue'; // @ is an alias to /src
     HelloWorld
   }
 })
-export default class Home extends Vue {}
+
+export default Vue.extend({
+  data: function() {
+    return {
+      search_word: "",
+      tableData: [],
+      total_data: 0,
+      loading: true
+    }
+  },
+  mounted() {
+    setTimeout(() => { this.loading = false; }, 2000);
+    axios.get('http://localhost/api/v1/AnalysisResultLists').then(
+        response => {
+            this.tableData = response.data.data
+            this.total_data = response.data.total
+        }
+    );
+  },
+  watch: {
+    search_word: function (val, oldVal) {
+    axios.get('http://localhost/api/v1/AnalysisResultLists?serach_word=' + val).then(
+        response => {
+            this.tableData = response.data.data
+            this.total_data = response.data.total
+        }
+    );
+      console.log('val ' + val + ", oldVal: " + oldVal)
+    }
+  },
+  methods: {
+    handleSizeChange(val) {
+      console.log(`${val} items per page`);
+      axios.get('http://localhost/api/v1/AnalysisResultLists?serach_word=' + this.search_word + '&page=' + val).then(response => {this.tableData = response.data.data;});
+
+       const h = this.$createElement;
+
+        this.$notify({
+          title: 'Title',
+          message: h('i', { style: 'color: teal' }, 'This is a reminder')
+        });
+    }
+  },
+});
+
+// export default class Home extends Vue {
+// 
+// }
 </script>
 <style scoped>
 .home {
   width: 1200px;
   margin: 0 auto;
 }
+
+<style>
+  .el-row {
+    margin-bottom: 20px;
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+  .el-col {
+    border-radius: 4px;
+  }
+  .bg-purple-dark {
+    background: #99a9bf;
+  }
+  .bg-purple {
+    background: #d3dce6;
+  }
+  .bg-purple-light {
+    background: #e5e9f2;
+  }
+  .grid-content {
+    border-radius: 4px;
+    min-height: 36px;
+    margin-bottom: 20px;
+  }
+  .row-bg {
+    padding: 10px 0;
+    background-color: #f9fafc;
+  }
+</style>
+
 </style>

--- a/src/views/AnalysisResultList.vue
+++ b/src/views/AnalysisResultList.vue
@@ -117,8 +117,9 @@ export default Vue.extend({
   width: 1200px;
   margin: 0 auto;
 }
-
-<style > .el-row {
+</style>
+<style>
+.el-row {
   margin-bottom: 20px;
   &:last-child {
     margin-bottom: 0;

--- a/src/views/AnalysisResultList.vue
+++ b/src/views/AnalysisResultList.vue
@@ -3,74 +3,37 @@
     <div class="home">解析結果一覧画面</div>
     <el-row>
       <el-col :span="24">
-        <div class="grid-content bg-purple-dark">
+        <div class="grid-content" style="background: #409EFF;color: white;">
           <div>検索ワード</div>
-             <el-input
-                 placeholder="Type something"
-                 prefix-icon="el-icon-search"
-                 v-model="search_word">
-             </el-input>
+          <el-input placeholder="Type something" prefix-icon="el-icon-search" v-model.lazy="search_word"> </el-input>
         </div>
       </el-col>
     </el-row>
     <el-row>
-      
       <el-col :span="24">
         <div class="grid-content bg-purple-dark">
-          <el-table
-             v-loading="loading"
-             :data="tableData"
-             stripe
-             style="width: 100%">
-             <el-table-column
-               prop="id"
-               label="ID"
-               width="180">
-             </el-table-column>
-             <el-table-column
-               prop="analysis_start_date"
-               label="検索開始日"
-               width="180">
-             </el-table-column>
-             <el-table-column
-               prop="analysis_end_date"
-               label="検索終了日"
-               width="180">
-             </el-table-column>
-             <el-table-column
-               prop="analysis_word"
-               label="検索ワード"
-               width="180">
-             </el-table-column>
-             <el-table-column
-               prop="status"
-               label="ステータス"
-               width="180">
-             </el-table-column>
-             <el-table-column
-               prop="favorite_count"
-               label="いいね数">
-             </el-table-column>
-             <el-table-column
-               prop="user_count"
-               label="ユーザ数">
-             </el-table-column>
-             <el-table-column
-               prop="tweet_count"
-               label="ツイート総数">
-             </el-table-column>
-
-
-           </el-table>
+          <el-table v-loading="loading" :data="tableData" stripe style="width: 100%" @row-click="redirectAnotherPage">
+            <el-table-column prop="id" label="ID" width="180"> </el-table-column>
+            <el-table-column prop="analysis_start_date" label="検索開始日" width="180"> </el-table-column>
+            <el-table-column prop="analysis_end_date" label="検索終了日" width="180"> </el-table-column>
+            <el-table-column prop="analysis_word" label="検索ワード" width="180"> </el-table-column>
+            <el-table-column prop="status" label="ステータス" width="180">
+              <template slot-scope="prop">
+                <el-tag type="info" v-if="prop.row.status === 0"><i class="el-icon-time"></i>&nbsp;処理待ち</el-tag>
+                <el-tag type="warning" v-else-if="prop.row.status === 1"><i class="el-icon-loading"></i>&nbsp;処理中</el-tag>
+                <el-tag type="success" v-else-if="prop.row.status === 2"><i class="el-icon-success"></i>&nbsp;完了</el-tag>
+                <el-tag type="danger" v-else-if="prop.row.status === 3"><i class="el-icon-error"></i>&nbsp;失敗</el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column prop="favorite_count" label="いいね数"> </el-table-column>
+            <el-table-column prop="user_count" label="ユーザ数"> </el-table-column>
+            <el-table-column prop="tweet_count" label="ツイート総数"> </el-table-column>
+          </el-table>
         </div>
       </el-col>
 
       <el-col :span="24">
-        <el-pagination
-          @current-change="handleSizeChange"
-          background
-          layout="prev, pager, next"
-          :total="total_data">
+        <el-pagination @current-change="handleSizeChange" background layout="prev, pager, next" :total="total_data">
         </el-pagination>
       </el-col>
     </el-row>
@@ -80,62 +43,74 @@
 <script lang="ts">
 import Vue from 'vue';
 import axios from 'axios';
-import { Component, Vue } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import HelloWorld from '@/components/HelloWorld.vue'; // @ is an alias to /src
-
-@Component({
-  components: {
-    HelloWorld
-  }
-})
 
 export default Vue.extend({
   data: function() {
     return {
-      search_word: "",
+      search_word: '',
       tableData: [],
       total_data: 0,
       loading: true
-    }
+    };
   },
-  mounted() {
-    setTimeout(() => { this.loading = false; }, 2000);
-    axios.get('http://localhost/api/v1/AnalysisResultLists').then(
-        response => {
-            this.tableData = response.data.data
-            this.total_data = response.data.total
-        }
-    );
+  mounted: function() {
+    this.getAnalysisResultList('', 1);
   },
   watch: {
-    search_word: function (val, oldVal) {
-    axios.get('http://localhost/api/v1/AnalysisResultLists?serach_word=' + val).then(
-        response => {
-            this.tableData = response.data.data
-            this.total_data = response.data.total
-        }
-    );
-      console.log('val ' + val + ", oldVal: " + oldVal)
+    search_word: function(newValue: string, oldValue: string) {
+      this.getAnalysisResultList(newValue, 1);
+      console.log('new value: ' + newValue + ', ' + 'old value: ' + oldValue);
     }
   },
   methods: {
-    handleSizeChange(val) {
-      console.log(`${val} items per page`);
-      axios.get('http://localhost/api/v1/AnalysisResultLists?serach_word=' + this.search_word + '&page=' + val).then(response => {this.tableData = response.data.data;});
+    handleSizeChange(page: number) {
+      this.getAnalysisResultList(this.search_word, page);
+    },
+    redirectAnotherPage(element: any) {
+      console.log(element.id);
+      this.$router.push({ path: `/analysisResult/${element.id}` });
+    },
+    getAnalysisResultList(searchWord: string, page: number) {
+      const params = [];
+      if (searchWord) {
+        params.push('search_word=' + searchWord);
+      }
+      if (page) {
+        params.push('page=' + page);
+      }
 
-       const h = this.$createElement;
+      this.loading = true;
+      const endpoint =
+        'http://localhost/api/v1/AnalysisResultLists' + (params.length !== 0 ? '?' + params.join('&') : '');
+      console.log(endpoint);
 
-        this.$notify({
-          title: 'Title',
-          message: h('i', { style: 'color: teal' }, 'This is a reminder')
+      axios
+        .get(endpoint, { timeout: 5000 })
+        .then(response => {
+          this.tableData = response.data.data;
+          this.total_data = response.data.total;
+          this.loading = false;
+        })
+        .catch(error => {
+          if (error.code === 'ECONNABORTED') {
+            // FIXME: this.$notify とするとtypescript が型エラーを出す。(this as any).$notify は暫定対処
+            (this as any).$notify.error({
+              title: 'Error',
+              message: 'サーバとの接続がタイムアウトしました'
+            });
+          } else {
+            (this as any).$notify.error({
+              title: 'Error',
+              message: 'データの取得に失敗しました'
+            });
+          }
+          this.loading = false;
         });
     }
-  },
+  }
 });
-
-// export default class Home extends Vue {
-// 
-// }
 </script>
 <style scoped>
 .home {
@@ -143,34 +118,31 @@ export default Vue.extend({
   margin: 0 auto;
 }
 
-<style>
-  .el-row {
-    margin-bottom: 20px;
-    &:last-child {
-      margin-bottom: 0;
-    }
+<style > .el-row {
+  margin-bottom: 20px;
+  &:last-child {
+    margin-bottom: 0;
   }
-  .el-col {
-    border-radius: 4px;
-  }
-  .bg-purple-dark {
-    background: #99a9bf;
-  }
-  .bg-purple {
-    background: #d3dce6;
-  }
-  .bg-purple-light {
-    background: #e5e9f2;
-  }
-  .grid-content {
-    border-radius: 4px;
-    min-height: 36px;
-    margin-bottom: 20px;
-  }
-  .row-bg {
-    padding: 10px 0;
-    background-color: #f9fafc;
-  }
-</style>
-
+}
+.el-col {
+  border-radius: 4px;
+}
+.bg-purple-dark {
+  background: #99a9bf;
+}
+.bg-purple {
+  background: #d3dce6;
+}
+.bg-purple-light {
+  background: #e5e9f2;
+}
+.grid-content {
+  border-radius: 4px;
+  min-height: 36px;
+  margin-bottom: 20px;
+}
+.row-bg {
+  padding: 10px 0;
+  background-color: #f9fafc;
+}
 </style>


### PR DESCRIPTION
前回解析結果一覧画面を。まだ改修が必要な場所はあると思いますが、これから改修とかやっていければと思います。
特に問題なければマージお願いします。

前回ペアプロ時のものから手を加えたこと
* ステータス表示をタグにした
* 行をクリックした時に詳細ページに遷移するように改修(仮で/analysisResult/${id}に遷移するように実装)
* axios 失敗した時にNotification を表示するように改修
* メインカラーを青に変更(仮で)

課題
* 処理やcss パラメータの共通化、リファクタリング
* this.$notify -> (this as any).$notify という書き方が気持ち悪い…(TSLint のエラー回避)