### PR TITLE
【解析依頼画面】画面とリクエストの処理を追加

### DIFF
--- a/src/views/AnalysisRequest.vue
+++ b/src/views/AnalysisRequest.vue
@@ -1,21 +1,94 @@
 <template>
-  <div class="home">解析依頼画面</div>
+  <div class="home">
+    <el-form ref="form" :model="form" label-width="120px">
+      <el-form-item label="日付">
+        <el-col :span="11">
+          <el-date-picker format="yyyy/MM/dd" value-format="yyyy/MM/dd" type="date" placeholder="Pick a date" v-model="form.date1" style="width: 100%;"></el-date-picker>
+        </el-col>
+      </el-form-item>
+      <el-form-item label="検索ワード">
+        <el-input v-model="form.search"></el-input>
+      </el-form-item>
+      <el-form-item label="URL">
+        <el-input v-model="form.url"></el-input>
+      </el-form-item>
+      <el-form-item label="解析タイミング">
+        <el-col :span="16">
+          <el-checkbox-group v-model="form.timing">
+            <el-checkbox label=0 name="timing" >今すぐ</el-checkbox>
+            <el-checkbox label=1 name="timing">3/3 23:59</el-checkbox>
+            <el-checkbox label=2 name="timing">3/4 23:59</el-checkbox>
+          </el-checkbox-group>
+        </el-col>
+      </el-form-item>
+      <el-form-item label="自動つぶやき">
+        <el-col :span="1">
+          <el-switch v-model="form.tweet"></el-switch>
+        </el-col>
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" @click="onSubmit">解析依頼</el-button>
+      </el-form-item>
+    </el-form>
+  </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import HelloWorld from '@/components/HelloWorld.vue'; // @ is an alias to /src
+import axios from 'axios';
 
-@Component({
-  components: {
-    HelloWorld
+export default Vue.extend({
+  data: function() {
+    return {
+      form: {
+        date1: '',
+        search: '',
+        url: '',
+        timing: [],
+        tweet: false
+      }
+    };
+  },
+  methods: {
+    onSubmit() {
+      console.log(this.form);
+      const endpoint = 'http://localhost/api/v1/AnalysisRequests';
+      const params = new URLSearchParams();
+      params.append('start_date', this.form.date1);
+      params.append('analysis_word', this.form.search);
+      params.append('url', this.form.url);
+      params.append('analysis_timing', '[' + this.form.timing.join(',') + ']');
+      params.append('auto_tweet', String(this.form.tweet));
+      console.log(params);
+
+      axios
+        .post(endpoint, params)
+        .then(response => {
+          console.log('完了');
+        })
+        .catch(error => {
+          if (error.code === 'ECONNABORTED') {
+            // FIXME: this.$notify とするとtypescript が型エラーを出す。(this as any).$notify は暫定対処
+            (this as any).$notify.error({
+              title: 'Error',
+              message: 'サーバとの接続がタイムアウトしました'
+            });
+          } else {
+            (this as any).$notify.error({
+              title: 'Error',
+              message: 'データの取得に失敗しました'
+            });
+          }
+        });
+    }
   }
-})
-export default class Home extends Vue {}
+});
 </script>
 <style scoped>
 .home {
-  width: 1200px;
+  width: 600px;
   margin: 0 auto;
+  margin-top: 10px;
 }
 </style>


### PR DESCRIPTION
# 対応内容
#54 #55 #56 #57 #58 の内容を対応をしました。

# 確認方法
解析依頼画面でformに入力して解析依頼ボタンを押してください。
問題なく終了する場合は、consoleログに完了が出力されます。
backend側ではword cloudの画像が生成されているはず。
<img width="1404" alt="スクリーンショット 2019-04-24 23 22 56" src="https://user-images.githubusercontent.com/34429882/56667462-d1cf9980-66e8-11e9-9bc1-cc8a930d8a9c.png">

# クローズするissue
close #54
close #55
close #56
close #57
close #58

# このタスクで発生したissue
特になし

# その他
特になし