### PR TITLE
Loadingの処理を追加

### DIFF
--- a/src/views/AnalysisRequest.vue
+++ b/src/views/AnalysisRequest.vue
@@ -67,7 +67,7 @@ export default Vue.extend({
   },
   methods: {
     onSubmit() {
-      const loading = this.$loading({
+      const loading = (this as any).$loading({
         lock: true,
         text: '解析中',
         spinner: 'el-icon-loading',

--- a/src/views/AnalysisRequest.vue
+++ b/src/views/AnalysisRequest.vue
@@ -27,9 +27,23 @@
         </el-col>
       </el-form-item>
       <el-form-item>
-        <el-button type="primary" @click="onSubmit">解析依頼</el-button>
+        <el-button type="primary" @click="centerDialogVisible = true">解析依頼</el-button>
       </el-form-item>
     </el-form>
+
+    <el-dialog title="下記内容で抽出します。よろしいですか？" :visible.sync="centerDialogVisible" width="250px;" center>
+      <div>
+        <div>日付:{{form.date1}}</div>
+        <div>検索ワード:{{form.search}}</div>
+        <div>URL:{{form.url}}</div>
+        <div>解析タイミング:【TODO】今後修正する</div>
+        <div>自動つぶやき:【TODO】今後修正する</div>
+      </div>
+      <span slot="footer" class="dialog-footer">
+        <el-button @click="centerDialogVisible = false">キャンセル</el-button>
+        <el-button type="primary" @click="onSubmit">解析</el-button>
+      </span>
+    </el-dialog>
   </div>
 </template>
 
@@ -47,7 +61,8 @@ export default Vue.extend({
         url: '',
         timing: [],
         tweet: false
-      }
+      },
+      centerDialogVisible: false
     };
   },
   methods: {
@@ -61,6 +76,7 @@ export default Vue.extend({
       params.append('analysis_timing', '[' + this.form.timing.join(',') + ']');
       params.append('auto_tweet', String(this.form.tweet));
       console.log(params);
+      this.centerDialogVisible = false;
 
       axios
         .post(endpoint, params)

--- a/src/views/AnalysisRequest.vue
+++ b/src/views/AnalysisRequest.vue
@@ -67,7 +67,13 @@ export default Vue.extend({
   },
   methods: {
     onSubmit() {
-      console.log(this.form);
+      const loading = this.$loading({
+        lock: true,
+        text: '解析中',
+        spinner: 'el-icon-loading',
+        background: 'rgba(0, 0, 0, 0.7)'
+      });
+
       const endpoint = 'http://localhost/api/v1/AnalysisRequests';
       const params = new URLSearchParams();
       params.append('start_date', this.form.date1);
@@ -75,15 +81,21 @@ export default Vue.extend({
       params.append('url', this.form.url);
       params.append('analysis_timing', '[' + this.form.timing.join(',') + ']');
       params.append('auto_tweet', String(this.form.tweet));
-      console.log(params);
+
       this.centerDialogVisible = false;
 
       axios
         .post(endpoint, params)
         .then(response => {
+          loading.close();
           console.log('完了');
         })
         .catch(error => {
+          // front画面のみで確認用で入れてます（実際は必要ない見込み）
+          setTimeout(() => {
+            loading.close();
+          }, 2000);
+
           if (error.code === 'ECONNABORTED') {
             // FIXME: this.$notify とするとtypescript が型エラーを出す。(this as any).$notify は暫定対処
             (this as any).$notify.error({


### PR DESCRIPTION
# 対応内容
#71 の内容を修正しました。

# 確認方法
#79 が先行のプルリクとなります。
解析ボタンを押すとLoadinが表示されることの確認をお願いします。
frontのみで確認できるようにするため、エラーのときもLoadingが出るようにしてます。（実際は不要）

<img width="653" alt="スクリーンショット 2019-05-01 14 44 50" src="https://user-images.githubusercontent.com/34429882/57007017-66258900-6c20-11e9-8437-c0f5fced00cb.png">

# クローズするissue
close #71 

# このタスクで発生したissue
解析が完了した際に、結果画面に遷移させる(もしくは一覧画面)
#80 

# その他
データが多いと待ち時間が長くなるので、ストレスになりそうな気もしました。
解析依頼したら、すぐに一覧画面に遷移させてもいいかもしれません。
解析が終わったら、ステータスが変更されるようにする。（Vuexの出番か？）