### PR TITLE
解析結果画面のレスポンス値のキャメルケースに対応

### DIFF
--- a/src/mockdata/testData.ts
+++ b/src/mockdata/testData.ts
@@ -1,981 +1,981 @@
 export const ANALYSIS_RESULT_LISTS = {
-  current_page: 1,
+  currentPage: 1,
   data: [
     {
       id: 1,
-      analysis_start_date: '2019-04-22 00:00:00',
-      analysis_end_date: '2019-04-22 23:59:59',
-      analysis_word: '#NGT48',
+      analysisStartDate: '2019-04-22 00:00:00',
+      analysisEndDate: '2019-04-22 23:59:59',
+      analysisWord: '#NGT48',
       status: 2,
-      tweet_count: 584,
-      favorite_count: 104,
-      user_count: 504,
+      tweetCount: 584,
+      favoriteCount: 104,
+      userCount: 504,
       image: 'dummy',
-      insert_date: '2019-04-29 13:27:12',
-      update_date: '2019-04-29 13:27:12',
-      delete_flag: 0,
+      insertDate: '2019-04-29 13:27:12',
+      updateDate: '2019-04-29 13:27:12',
+      deleteFlag: 0,
       url: 'https://github.com/nsuzuki7713/a6s-cloud-front/',
-      retweet_count: 120
+      retweetCount: 120
     },
     {
       id: 2,
-      analysis_start_date: '2019-04-29 00:00:00',
-      analysis_end_date: '2019-04-29 23:59:59',
-      analysis_word: '#ゼロの執行人',
+      analysisStartDate: '2019-04-29 00:00:00',
+      analysisEndDate: '2019-04-29 23:59:59',
+      analysisWord: '#ゼロの執行人',
       status: 2,
-      tweet_count: 724,
-      favorite_count: 66,
-      user_count: 582,
+      tweetCount: 724,
+      favoriteCount: 66,
+      userCount: 582,
       image: '111a364f-45c0-4697-87c5-e37788c22bda.png',
-      insert_date: '2019-04-29 13:29:14',
-      update_date: '2019-04-29 13:29:36',
-      delete_flag: 0,
+      insertDate: '2019-04-29 13:29:14',
+      updateDate: '2019-04-29 13:29:36',
+      deleteFlag: 0,
       url: null,
-      retweet_count: 3404995
+      retweetCount: 3404995
     }
   ],
-  first_page_url: 'http://localhost/api/v1/AnalysisResultLists?page=1',
+  firstPageUrl: 'http://localhost/api/v1/AnalysisResultLists?page=1',
   from: 1,
-  last_page: 1,
-  last_page_url: 'http://localhost/api/v1/AnalysisResultLists?page=1',
-  next_page_url: null,
+  lastPage: 1,
+  lastPageUrl: 'http://localhost/api/v1/AnalysisResultLists?page=1',
+  nextPageUrl: null,
   path: 'http://localhost/api/v1/AnalysisResultLists',
-  per_page: 10,
-  prev_page_url: null,
+  perPage: 10,
+  prevPageUrl: null,
   to: 2,
   total: 2
 };
 
 export const ANALYSIS_RESULT = {
   id: 2,
-  analysis_start_date: '2019-04-29 00:00:00',
-  analysis_end_date: '2019-04-29 23:59:59',
-  analysis_word: '#ゼロの執行人',
+  analysisStartDate: '2019-04-29 00:00:00',
+  analysisEndDate: '2019-04-29 23:59:59',
+  analysisWord: '#ゼロの執行人',
   status: 2,
-  tweet_count: 724,
-  favorite_count: 66,
-  user_count: 582,
+  tweetCount: 724,
+  favoriteCount: 66,
+  userCount: 582,
   image: 'dummy',
-  insert_date: '2019-04-29 13:29:14',
-  update_date: '2019-04-29 13:29:36',
-  delete_flag: 0,
+  insertDate: '2019-04-29 13:29:14',
+  updateDate: '2019-04-29 13:29:36',
+  deleteFlag: 0,
   url: null,
-  retweet_count: 3404995,
-  user_ranking: [
+  retweetCount: 3404995,
+  userRanking: [
     {
-      user_name: 'しきゃん🍥🍤',
-      user_account: 'narsesiki_A34',
-      tweet_count: 39
+      userName: 'しきゃん🍥🍤',
+      userAccount: 'narsesiki_A34',
+      tweetCount: 39
     },
     {
-      user_name: 'クリームぱんまん',
-      user_account: '5l7jY8YSbFJgztf',
-      tweet_count: 18
+      userName: 'クリームぱんまん',
+      userAccount: '5l7jY8YSbFJgztf',
+      tweetCount: 18
     },
     {
-      user_name: '日向　馨',
-      user_account: 'hidamari_kh',
-      tweet_count: 14
+      userName: '日向　馨',
+      userAccount: 'hidamari_kh',
+      tweetCount: 14
     },
     {
-      user_name: 'ゆき！☠️🐬🏊🏻‍♀️(ひゅうがくんLOVE❤️)(Free大好き❤️)',
-      user_account: 'yuki_0301_2398',
-      tweet_count: 14
+      userName: 'ゆき！☠️🐬🏊🏻‍♀️(ひゅうがくんLOVE❤️)(Free大好き❤️)',
+      userAccount: 'yuki_0301_2398',
+      tweetCount: 14
     },
     {
-      user_name: '五月雨',
-      user_account: 'Ayame4Airisu',
-      tweet_count: 6
+      userName: '五月雨',
+      userAccount: 'Ayame4Airisu',
+      tweetCount: 6
     },
     {
-      user_name: 'vanillaswissalmondഒ',
-      user_account: 'KrrkriYu',
-      tweet_count: 6
+      userName: 'vanillaswissalmondഒ',
+      userAccount: 'KrrkriYu',
+      tweetCount: 6
     },
     {
-      user_name: 'たけうち🌉.｡oO(No Image)',
-      user_account: 'takeuchi_cope',
-      tweet_count: 6
+      userName: 'たけうち🌉.｡oO(No Image)',
+      userAccount: 'takeuchi_cope',
+      tweetCount: 6
     },
     {
-      user_name: '✿Kaco✿',
-      user_account: 'greenleaves025',
-      tweet_count: 5
+      userName: '✿Kaco✿',
+      userAccount: 'greenleaves025',
+      tweetCount: 5
     },
     {
-      user_name: 'Andoma',
-      user_account: 'Andoma5',
-      tweet_count: 4
+      userName: 'Andoma',
+      userAccount: 'Andoma5',
+      tweetCount: 4
     },
     {
-      user_name: 'アリサ',
-      user_account: 'arisa0618s',
-      tweet_count: 4
+      userName: 'アリサ',
+      userAccount: 'arisa0618s',
+      tweetCount: 4
     },
     {
-      user_name: '小鳥遊',
-      user_account: 'tknsayano',
-      tweet_count: 3
+      userName: '小鳥遊',
+      userAccount: 'tknsayano',
+      tweetCount: 3
     },
     {
-      user_name: 'kiyo',
-      user_account: 'kiyooooooooooo',
-      tweet_count: 3
+      userName: 'kiyo',
+      userAccount: 'kiyooooooooooo',
+      tweetCount: 3
     },
     {
-      user_name: 'あたしiらんど',
-      user_account: 'anmito1412',
-      tweet_count: 3
+      userName: 'あたしiらんど',
+      userAccount: 'anmito1412',
+      tweetCount: 3
     },
     {
-      user_name: '英『はなぶさ』＠ セブと哀ちゃんを幸せに',
-      user_account: 'gosho_watase_',
-      tweet_count: 2
+      userName: '英『はなぶさ』＠ セブと哀ちゃんを幸せに',
+      userAccount: 'gosho_watase_',
+      tweetCount: 2
     },
     {
-      user_name: 'Ayuna',
-      user_account: 'ayuna_5040',
-      tweet_count: 2
+      userName: 'Ayuna',
+      userAccount: 'ayuna_5040',
+      tweetCount: 2
     },
     {
-      user_name: 'あゆみ',
-      user_account: 'L5O07DxCMItlner',
-      tweet_count: 2
+      userName: 'あゆみ',
+      userAccount: 'L5O07DxCMItlner',
+      tweetCount: 2
     },
     {
-      user_name: 'B E  ＫO B E  Ｓ U M A  知って欲しいねん❣️',
-      user_account: 'IWQkycrQ8yYyRSM',
-      tweet_count: 2
+      userName: 'B E  ＫO B E  Ｓ U M A  知って欲しいねん❣️',
+      userAccount: 'IWQkycrQ8yYyRSM',
+      tweetCount: 2
     },
     {
-      user_name: '∠コッシー@3出国済👊💎🇸🇬',
-      user_account: 'PGloveDC',
-      tweet_count: 2
+      userName: '∠コッシー@3出国済👊💎🇸🇬',
+      userAccount: 'PGloveDC',
+      tweetCount: 2
     },
     {
-      user_name: 'KUMIK☺︎',
-      user_account: 'kumi_chan935',
-      tweet_count: 2
+      userName: 'KUMIK☺︎',
+      userAccount: 'kumi_chan935',
+      tweetCount: 2
     },
     {
-      user_name: '♡しの♡紘翔♡来栖 藍♡',
-      user_account: 's1n0_tk',
-      tweet_count: 2
+      userName: '♡しの♡紘翔♡来栖 藍♡',
+      userAccount: 's1n0_tk',
+      tweetCount: 2
     },
     {
-      user_name: 'unknown',
-      user_account: 'custom823',
-      tweet_count: 2
+      userName: 'unknown',
+      userAccount: 'custom823',
+      tweetCount: 2
     },
     {
-      user_name: 'Yu-Hui Chen',
-      user_account: 'victonia_yu',
-      tweet_count: 2
+      userName: 'Yu-Hui Chen',
+      userAccount: 'victonia_yu',
+      tweetCount: 2
     },
     {
-      user_name: 'クロシェット@お取引はツイフィ必読',
-      user_account: 'GvwPo1SigfviRx5',
-      tweet_count: 2
+      userName: 'クロシェット@お取引はツイフィ必読',
+      userAccount: 'GvwPo1SigfviRx5',
+      tweetCount: 2
     },
     {
-      user_name: 'カヨ',
-      user_account: 'cnys12mt',
-      tweet_count: 2
+      userName: 'カヨ',
+      userAccount: 'cnys12mt',
+      tweetCount: 2
     },
     {
-      user_name: 'Aoi Rika A.R',
-      user_account: 'aoirikaAR2',
-      tweet_count: 2
+      userName: 'Aoi Rika A.R',
+      userAccount: 'aoirikaAR2',
+      tweetCount: 2
     },
     {
-      user_name: '北北西',
-      user_account: 'pipicaz',
-      tweet_count: 2
+      userName: '北北西',
+      userAccount: 'pipicaz',
+      tweetCount: 2
     },
     {
-      user_name: 'ちーぼー',
-      user_account: 'c0h8i0e1',
-      tweet_count: 2
+      userName: 'ちーぼー',
+      userAccount: 'c0h8i0e1',
+      tweetCount: 2
     },
     {
-      user_name: 'みるくかかお',
-      user_account: 'OkaO_mukiryoku2',
-      tweet_count: 2
+      userName: 'みるくかかお',
+      userAccount: 'OkaO_mukiryoku2',
+      tweetCount: 2
     },
     {
-      user_name: '壱丸太',
-      user_account: '1maruta',
-      tweet_count: 2
+      userName: '壱丸太',
+      userAccount: '1maruta',
+      tweetCount: 2
     },
     {
-      user_name: 'juーる🌸5/4西1ケ04b',
-      user_account: 'ju_le93',
-      tweet_count: 2
+      userName: 'juーる🌸5/4西1ケ04b',
+      userAccount: 'ju_le93',
+      tweetCount: 2
     },
     {
-      user_name: 'ポニ',
-      user_account: 'hinoe626',
-      tweet_count: 2
+      userName: 'ポニ',
+      userAccount: 'hinoe626',
+      tweetCount: 2
     },
     {
-      user_name: 'さくらんぼ🍒',
-      user_account: '9_qk9z',
-      tweet_count: 2
+      userName: 'さくらんぼ🍒',
+      userAccount: '9_qk9z',
+      tweetCount: 2
     },
     {
-      user_name: 'Dスケブログ',
-      user_account: 'dsk4444',
-      tweet_count: 2
+      userName: 'Dスケブログ',
+      userAccount: 'dsk4444',
+      tweetCount: 2
     },
     {
-      user_name: 'さいたま市桜区 林田カイロプラクティック院',
-      user_account: 'chiropr',
-      tweet_count: 2
+      userName: 'さいたま市桜区 林田カイロプラクティック院',
+      userAccount: 'chiropr',
+      tweetCount: 2
     },
     {
-      user_name: 'くぅ汰はコミ障',
-      user_account: 'CwEF3o90pfDdoCy',
-      tweet_count: 2
+      userName: 'くぅ汰はコミ障',
+      userAccount: 'CwEF3o90pfDdoCy',
+      tweetCount: 2
     },
     {
-      user_name: 'ブルー',
-      user_account: 'bluexxxRyouka',
-      tweet_count: 2
+      userName: 'ブルー',
+      userAccount: 'bluexxxRyouka',
+      tweetCount: 2
     },
     {
-      user_name: '鵜羅',
-      user_account: 'sizin613ura',
-      tweet_count: 2
+      userName: '鵜羅',
+      userAccount: 'sizin613ura',
+      tweetCount: 2
     },
     {
-      user_name: '安室の女',
-      user_account: 'acesamabanzai',
-      tweet_count: 2
+      userName: '安室の女',
+      userAccount: 'acesamabanzai',
+      tweetCount: 2
     },
     {
-      user_name: '新那.',
-      user_account: 'niina_82039',
-      tweet_count: 2
+      userName: '新那.',
+      userAccount: 'niina_82039',
+      tweetCount: 2
     },
     {
-      user_name: 'ケーキ',
-      user_account: 'ThinkPa37077851',
-      tweet_count: 2
+      userName: 'ケーキ',
+      userAccount: 'ThinkPa37077851',
+      tweetCount: 2
     },
     {
-      user_name: '服部伸哉@株・暗号・FX・ETH',
-      user_account: 'sinyahattori',
-      tweet_count: 2
+      userName: '服部伸哉@株・暗号・FX・ETH',
+      userAccount: 'sinyahattori',
+      tweetCount: 2
     },
     {
-      user_name: '乃木バナナ',
-      user_account: 'VALSHE_N46',
-      tweet_count: 2
+      userName: '乃木バナナ',
+      userAccount: 'VALSHE_N46',
+      tweetCount: 2
     },
     {
-      user_name: 'ふう',
-      user_account: 'CAiuODOfehkAQtL',
-      tweet_count: 2
+      userName: 'ふう',
+      userAccount: 'CAiuODOfehkAQtL',
+      tweetCount: 2
     },
     {
-      user_name: 'JUNE CH.',
-      user_account: 'Shineboots',
-      tweet_count: 1
+      userName: 'JUNE CH.',
+      userAccount: 'Shineboots',
+      tweetCount: 1
     },
     {
-      user_name: 'ふじわら',
-      user_account: 'f_wara_da_1',
-      tweet_count: 1
+      userName: 'ふじわら',
+      userAccount: 'f_wara_da_1',
+      tweetCount: 1
     },
     {
-      user_name: 'KaGomFit',
-      user_account: 'gom_fit',
-      tweet_count: 1
+      userName: 'KaGomFit',
+      userAccount: 'gom_fit',
+      tweetCount: 1
     },
     {
-      user_name: 'F・T',
-      user_account: 'fu_ohito',
-      tweet_count: 1
+      userName: 'F・T',
+      userAccount: 'fu_ohito',
+      tweetCount: 1
     },
     {
-      user_name: 'Colune',
-      user_account: 'Yu_ColuN',
-      tweet_count: 1
+      userName: 'Colune',
+      userAccount: 'Yu_ColuN',
+      tweetCount: 1
     },
     {
-      user_name: '💟❁ なぴふ ❁💟',
-      user_account: 'npy_Dufgela',
-      tweet_count: 1
+      userName: '💟❁ なぴふ ❁💟',
+      userAccount: 'npy_Dufgela',
+      tweetCount: 1
     },
     {
-      user_name: 'AI@問題児組',
-      user_account: 'mm111817',
-      tweet_count: 1
+      userName: 'AI@問題児組',
+      userAccount: 'mm111817',
+      tweetCount: 1
     },
     {
-      user_name: 'SHO@湾岸',
-      user_account: 'sho_r8_brz_r33',
-      tweet_count: 1
+      userName: 'SHO@湾岸',
+      userAccount: 'sho_r8_brz_r33',
+      tweetCount: 1
     },
     {
-      user_name: 'りりりり',
-      user_account: 'EoWA111',
-      tweet_count: 1
+      userName: 'りりりり',
+      userAccount: 'EoWA111',
+      tweetCount: 1
     },
     {
-      user_name: 'ノア',
-      user_account: 't_t_m_s_t',
-      tweet_count: 1
+      userName: 'ノア',
+      userAccount: 't_t_m_s_t',
+      tweetCount: 1
     },
     {
-      user_name: 'いちひな',
-      user_account: '1hinageki',
-      tweet_count: 1
+      userName: 'いちひな',
+      userAccount: '1hinageki',
+      tweetCount: 1
     },
     {
-      user_name: 'りま',
-      user_account: 'Rima_tkmr',
-      tweet_count: 1
+      userName: 'りま',
+      userAccount: 'Rima_tkmr',
+      tweetCount: 1
     },
     {
-      user_name: '早瀬友行＠4/28東近江TTエントリー',
-      user_account: 'hayase765',
-      tweet_count: 1
+      userName: '早瀬友行＠4/28東近江TTエントリー',
+      userAccount: 'hayase765',
+      tweetCount: 1
     },
     {
-      user_name: 'とにー',
-      user_account: 'heyheybody393',
-      tweet_count: 1
+      userName: 'とにー',
+      userAccount: 'heyheybody393',
+      tweetCount: 1
     },
     {
-      user_name: 'Yuuki',
-      user_account: 'Yuuki82926364',
-      tweet_count: 1
+      userName: 'Yuuki',
+      userAccount: 'Yuuki82926364',
+      tweetCount: 1
     },
     {
-      user_name: 'はるか👊💎',
-      user_account: 'hrksdc',
-      tweet_count: 1
+      userName: 'はるか👊💎',
+      userAccount: 'hrksdc',
+      tweetCount: 1
     },
     {
-      user_name: '🌸⚽川崎ゆきみん⚽🌸',
-      user_account: 'HAPPA_YUME',
-      tweet_count: 1
+      userName: '🌸⚽川崎ゆきみん⚽🌸',
+      userAccount: 'HAPPA_YUME',
+      tweetCount: 1
     },
     {
-      user_name: 'ぶたぐう',
-      user_account: 'kona_cobule',
-      tweet_count: 1
+      userName: 'ぶたぐう',
+      userAccount: 'kona_cobule',
+      tweetCount: 1
     },
     {
-      user_name: 'TAKAnali aka タカちゃん',
-      user_account: 'TAKAnaliTAP',
-      tweet_count: 1
+      userName: 'TAKAnali aka タカちゃん',
+      userAccount: 'TAKAnaliTAP',
+      tweetCount: 1
     },
     {
-      user_name: 'よしこ',
-      user_account: 'moocha321',
-      tweet_count: 1
+      userName: 'よしこ',
+      userAccount: 'moocha321',
+      tweetCount: 1
     },
     {
-      user_name: 'ぜんちゃんS',
-      user_account: 'I1I1I1I',
-      tweet_count: 1
+      userName: 'ぜんちゃんS',
+      userAccount: 'I1I1I1I',
+      tweetCount: 1
     },
     {
-      user_name: 'こ こ あ 💍ゆっちゃん愛してる💍',
-      user_account: 'kid_kokoa_',
-      tweet_count: 1
+      userName: 'こ こ あ 💍ゆっちゃん愛してる💍',
+      userAccount: 'kid_kokoa_',
+      tweetCount: 1
     },
     {
-      user_name: '💎🎩あおい☕🥪出国済み',
-      user_account: 'Aoixxx527',
-      tweet_count: 1
+      userName: '💎🎩あおい☕🥪出国済み',
+      userAccount: 'Aoixxx527',
+      tweetCount: 1
     },
     {
-      user_name: '水素【ほのか】',
-      user_account: 'honosub_H2',
-      tweet_count: 1
+      userName: '水素【ほのか】',
+      userAccount: 'honosub_H2',
+      tweetCount: 1
     },
     {
-      user_name: 'は.ぶ.ゆ.ー',
-      user_account: 'hbyu10_1',
-      tweet_count: 1
+      userName: 'は.ぶ.ゆ.ー',
+      userAccount: 'hbyu10_1',
+      tweetCount: 1
     },
     {
-      user_name: 'σ(`〇ω〇)σﾍﾟｪ',
-      user_account: 'EtG7TZlqmkwIG8C',
-      tweet_count: 1
+      userName: 'σ(`〇ω〇)σﾍﾟｪ',
+      userAccount: 'EtG7TZlqmkwIG8C',
+      tweetCount: 1
     },
     {
-      user_name: 'なか▶️固ツイよろ',
-      user_account: 'sk___bm_369',
-      tweet_count: 1
+      userName: 'なか▶️固ツイよろ',
+      userAccount: 'sk___bm_369',
+      tweetCount: 1
     },
     {
-      user_name: 'ライ💎出国済',
-      user_account: 'Saaakiii0328___',
-      tweet_count: 1
+      userName: 'ライ💎出国済',
+      userAccount: 'Saaakiii0328___',
+      tweetCount: 1
     },
     {
-      user_name: 'Asahi',
-      user_account: 'A_SA_HI4869',
-      tweet_count: 1
+      userName: 'Asahi',
+      userAccount: 'A_SA_HI4869',
+      tweetCount: 1
     },
     {
-      user_name: 'ののの彩乃',
-      user_account: 'mknths1223pk',
-      tweet_count: 1
+      userName: 'ののの彩乃',
+      userAccount: 'mknths1223pk',
+      tweetCount: 1
     },
     {
-      user_name: 'Mnia（エムニア）🇬🇧',
-      user_account: 'wotdaradara',
-      tweet_count: 1
+      userName: 'Mnia（エムニア）🇬🇧',
+      userAccount: 'wotdaradara',
+      tweetCount: 1
     },
     {
-      user_name: '結空斗',
-      user_account: '5__Aomine',
-      tweet_count: 1
+      userName: '結空斗',
+      userAccount: '5__Aomine',
+      tweetCount: 1
     },
     {
-      user_name: 'えりお',
-      user_account: '626natuo',
-      tweet_count: 1
+      userName: 'えりお',
+      userAccount: '626natuo',
+      tweetCount: 1
     },
     {
-      user_name: '斗娜楼東風(となつきあゆ)',
-      user_account: 'tonatuki',
-      tweet_count: 1
+      userName: '斗娜楼東風(となつきあゆ)',
+      userAccount: 'tonatuki',
+      tweetCount: 1
     },
     {
-      user_name: '芋',
-      user_account: 'oimooooooon',
-      tweet_count: 1
+      userName: '芋',
+      userAccount: 'oimooooooon',
+      tweetCount: 1
     },
     {
-      user_name: '高円寺銀三',
-      user_account: 'ginkananegi',
-      tweet_count: 1
+      userName: '高円寺銀三',
+      userAccount: 'ginkananegi',
+      tweetCount: 1
     },
     {
-      user_name: 'らしんばんオンライン＠中古買取販売',
-      user_account: 'lashin_tsuuhan',
-      tweet_count: 1
+      userName: 'らしんばんオンライン＠中古買取販売',
+      userAccount: 'lashin_tsuuhan',
+      tweetCount: 1
     },
     {
-      user_name: 'ひろ',
-      user_account: 'TrySail_hiro',
-      tweet_count: 1
+      userName: 'ひろ',
+      userAccount: 'TrySail_hiro',
+      tweetCount: 1
     },
     {
-      user_name: 'マサ',
-      user_account: 'yoshinari_ma',
-      tweet_count: 1
+      userName: 'マサ',
+      userAccount: 'yoshinari_ma',
+      tweetCount: 1
     },
     {
-      user_name: '誠',
-      user_account: 'a4n4r1i',
-      tweet_count: 1
+      userName: '誠',
+      userAccount: 'a4n4r1i',
+      tweetCount: 1
     },
     {
-      user_name: '舞鶴',
-      user_account: 'maizuru_poolLBM',
-      tweet_count: 1
+      userName: '舞鶴',
+      userAccount: 'maizuru_poolLBM',
+      tweetCount: 1
     },
     {
-      user_name: '( こ ま )👊💥💎済( お か め )',
-      user_account: 'KOMA__OKAME',
-      tweet_count: 1
+      userName: '( こ ま )👊💥💎済( お か め )',
+      userAccount: 'KOMA__OKAME',
+      tweetCount: 1
     },
     {
-      user_name: 'りな',
-      user_account: 'rina__ar_di',
-      tweet_count: 1
+      userName: 'りな',
+      userAccount: 'rina__ar_di',
+      tweetCount: 1
     },
     {
-      user_name: '(´∀｀)＜ニッコ！',
-      user_account: 'b_one_piece',
-      tweet_count: 1
+      userName: '(´∀｀)＜ニッコ！',
+      userAccount: 'b_one_piece',
+      tweetCount: 1
     },
     {
-      user_name: '唐辛子',
-      user_account: 'karashi3201',
-      tweet_count: 1
+      userName: '唐辛子',
+      userAccount: 'karashi3201',
+      tweetCount: 1
     },
     {
-      user_name: '坂口',
-      user_account: 'hEf3cf0vri1J7j1',
-      tweet_count: 1
+      userName: '坂口',
+      userAccount: 'hEf3cf0vri1J7j1',
+      tweetCount: 1
     },
     {
-      user_name: 'サク@オタ森のダイヤ砕く人',
-      user_account: 'adel_3939',
-      tweet_count: 1
+      userName: 'サク@オタ森のダイヤ砕く人',
+      userAccount: 'adel_3939',
+      tweetCount: 1
     },
     {
-      user_name: '零音',
-      user_account: 'lav_alcohol',
-      tweet_count: 1
+      userName: '零音',
+      userAccount: 'lav_alcohol',
+      tweetCount: 1
     },
     {
-      user_name: '髏爾🥃',
-      user_account: 'rei8370',
-      tweet_count: 1
+      userName: '髏爾🥃',
+      userAccount: 'rei8370',
+      tweetCount: 1
     },
     {
-      user_name: 'ケロリーナ@脊オパ北海道17/幕張11',
-      user_account: 'kaeluchann',
-      tweet_count: 1
+      userName: 'ケロリーナ@脊オパ北海道17/幕張11',
+      userAccount: 'kaeluchann',
+      tweetCount: 1
     },
     {
-      user_name: '夏風',
-      user_account: 'NATSU731KAZE314',
-      tweet_count: 1
+      userName: '夏風',
+      userAccount: 'NATSU731KAZE314',
+      tweetCount: 1
     },
     {
-      user_name: '夏希🤜💥🤛',
-      user_account: 'Poirot0504',
-      tweet_count: 1
+      userName: '夏希🤜💥🤛',
+      userAccount: 'Poirot0504',
+      tweetCount: 1
     },
     {
-      user_name: 'しゅー',
-      user_account: 'torisyu2515',
-      tweet_count: 1
+      userName: 'しゅー',
+      userAccount: 'torisyu2515',
+      tweetCount: 1
     },
     {
-      user_name: 'ハピハピ皇帝サルタン',
-      user_account: 'hapihapisultanx',
-      tweet_count: 1
+      userName: 'ハピハピ皇帝サルタン',
+      userAccount: 'hapihapisultanx',
+      tweetCount: 1
     },
     {
-      user_name: 'はっぱ@5/4令和梶さん♥カラマリ舞台♥',
-      user_account: 'kureha08130000',
-      tweet_count: 1
+      userName: 'はっぱ@5/4令和梶さん♥カラマリ舞台♥',
+      userAccount: 'kureha08130000',
+      tweetCount: 1
     },
     {
-      user_name: 'ま〜青海Ｂイ12b',
-      user_account: 'solasolama',
-      tweet_count: 1
+      userName: 'ま〜青海Ｂイ12b',
+      userAccount: 'solasolama',
+      tweetCount: 1
     },
     {
-      user_name: '헐',
-      user_account: 'Haru__Lovexoxo',
-      tweet_count: 1
+      userName: '헐',
+      userAccount: 'Haru__Lovexoxo',
+      tweetCount: 1
     },
     {
-      user_name: '子',
-      user_account: '9na1no',
-      tweet_count: 1
+      userName: '子',
+      userAccount: '9na1no',
+      tweetCount: 1
     },
     {
-      user_name: 'めめ⌒★',
-      user_account: 'me____kn',
-      tweet_count: 1
+      userName: 'めめ⌒★',
+      userAccount: 'me____kn',
+      tweetCount: 1
     },
     {
-      user_name: '真知★',
-      user_account: 'lunax_lunaire23',
-      tweet_count: 1
+      userName: '真知★',
+      userAccount: 'lunax_lunaire23',
+      tweetCount: 1
     },
     {
-      user_name: 'カザミネ',
-      user_account: 'gure_neko',
-      tweet_count: 1
+      userName: 'カザミネ',
+      userAccount: 'gure_neko',
+      tweetCount: 1
     },
     {
-      user_name: 'がく太郎',
-      user_account: '8yWd1e',
-      tweet_count: 1
+      userName: 'がく太郎',
+      userAccount: '8yWd1e',
+      tweetCount: 1
     },
     {
-      user_name: 'みことのり@出国してきた×2',
-      user_account: 'Luke_gowther5',
-      tweet_count: 1
+      userName: 'みことのり@出国してきた×2',
+      userAccount: 'Luke_gowther5',
+      tweetCount: 1
     },
     {
-      user_name: 'おもち',
-      user_account: 'omochi_much',
-      tweet_count: 1
+      userName: 'おもち',
+      userAccount: 'omochi_much',
+      tweetCount: 1
     },
     {
-      user_name: 'Kao@(͒๑⃙⃘´ཅ`๑⃙⃘)͒◞ෆ',
-      user_account: 'Kapr18er',
-      tweet_count: 1
+      userName: 'Kao@(͒๑⃙⃘´ཅ`๑⃙⃘)͒◞ෆ',
+      userAccount: 'Kapr18er',
+      tweetCount: 1
     },
     {
-      user_name: 'suiga@名前が多い人',
-      user_account: 'hisui_suiga',
-      tweet_count: 1
+      userName: 'suiga@名前が多い人',
+      userAccount: 'hisui_suiga',
+      tweetCount: 1
     },
     {
-      user_name: '不夢安想さん@暇な不夢ちゃんは遂にスーモと化す',
-      user_account: 'ansousan_1028',
-      tweet_count: 1
+      userName: '不夢安想さん@暇な不夢ちゃんは遂にスーモと化す',
+      userAccount: 'ansousan_1028',
+      tweetCount: 1
     },
     {
-      user_name: 'テカテカはじめ🐥🐥',
-      user_account: 'hjm_13',
-      tweet_count: 1
+      userName: 'テカテカはじめ🐥🐥',
+      userAccount: 'hjm_13',
+      tweetCount: 1
     },
     {
-      user_name: 'めろ。@最推しは独歩、りしらまなさん',
-      user_account: '11574a',
-      tweet_count: 1
+      userName: 'めろ。@最推しは独歩、りしらまなさん',
+      userAccount: '11574a',
+      tweetCount: 1
     },
     {
-      user_name: 'こゆき',
-      user_account: 'f_bonbon52',
-      tweet_count: 1
+      userName: 'こゆき',
+      userAccount: 'f_bonbon52',
+      tweetCount: 1
     },
     {
-      user_name: 'ゆづ',
-      user_account: 'yudu_dududududu',
-      tweet_count: 1
+      userName: 'ゆづ',
+      userAccount: 'yudu_dududududu',
+      tweetCount: 1
     },
     {
-      user_name: '島崎たかや',
-      user_account: 'takaya_simazaki',
-      tweet_count: 1
+      userName: '島崎たかや',
+      userAccount: 'takaya_simazaki',
+      tweetCount: 1
     },
     {
-      user_name: 'ぴよきのこ💎出国済',
-      user_account: 'lepisu8267',
-      tweet_count: 1
+      userName: 'ぴよきのこ💎出国済',
+      userAccount: 'lepisu8267',
+      tweetCount: 1
     },
     {
-      user_name: 'ゆーな(｡☌ᴗ☌｡)💖',
-      user_account: 'yuuna_4563',
-      tweet_count: 1
+      userName: 'ゆーな(｡☌ᴗ☌｡)💖',
+      userAccount: 'yuuna_4563',
+      tweetCount: 1
     },
     {
-      user_name: '喪に服すまどか',
-      user_account: 'mdmd_02',
-      tweet_count: 1
+      userName: '喪に服すまどか',
+      userAccount: 'mdmd_02',
+      tweetCount: 1
     },
     {
-      user_name: 'なぴふ@西野家',
-      user_account: 'nnpy_nishinoke',
-      tweet_count: 1
+      userName: 'なぴふ@西野家',
+      userAccount: 'nnpy_nishinoke',
+      tweetCount: 1
     },
     {
-      user_name: 'しおん@推しに貢ぐ宿命',
-      user_account: 's_12_piano',
-      tweet_count: 1
+      userName: 'しおん@推しに貢ぐ宿命',
+      userAccount: 's_12_piano',
+      tweetCount: 1
     },
     {
-      user_name: '哀ちゃん love',
-      user_account: 'tChktpdApA4dpCy',
-      tweet_count: 1
+      userName: '哀ちゃん love',
+      userAccount: 'tChktpdApA4dpCy',
+      tweetCount: 1
     },
     {
-      user_name: '凌子',
-      user_account: 'CJUvStXn2zxzWG8',
-      tweet_count: 1
+      userName: '凌子',
+      userAccount: 'CJUvStXn2zxzWG8',
+      tweetCount: 1
     },
     {
-      user_name: 'めぐるめく',
-      user_account: 'megurumeku_riu',
-      tweet_count: 1
+      userName: 'めぐるめく',
+      userAccount: 'megurumeku_riu',
+      tweetCount: 1
     },
     {
-      user_name: 'Taro Takizawa',
-      user_account: 'tarotakizawart',
-      tweet_count: 1
+      userName: 'Taro Takizawa',
+      userAccount: 'tarotakizawart',
+      tweetCount: 1
     },
     {
-      user_name: '勇者あづさん@安室の女',
-      user_account: 'azusa_chan',
-      tweet_count: 1
+      userName: '勇者あづさん@安室の女',
+      userAccount: 'azusa_chan',
+      tweetCount: 1
     },
     {
-      user_name: '輝',
-      user_account: 'kou00707',
-      tweet_count: 1
+      userName: '輝',
+      userAccount: 'kou00707',
+      tweetCount: 1
     },
     {
-      user_name: 'ちろる❖',
-      user_account: 'tir0l_19',
-      tweet_count: 1
+      userName: 'ちろる❖',
+      userAccount: 'tir0l_19',
+      tweetCount: 1
     },
     {
-      user_name: '青',
-      user_account: 'blueblue1115',
-      tweet_count: 1
+      userName: '青',
+      userAccount: 'blueblue1115',
+      tweetCount: 1
     },
     {
-      user_name: 'もふこま',
-      user_account: 'T1ApmMXshTZaI5K',
-      tweet_count: 1
+      userName: 'もふこま',
+      userAccount: 'T1ApmMXshTZaI5K',
+      tweetCount: 1
     },
     {
-      user_name: 'もなこ',
-      user_account: 'momonatsu_zatta',
-      tweet_count: 1
+      userName: 'もなこ',
+      userAccount: 'momonatsu_zatta',
+      tweetCount: 1
     },
     {
-      user_name: '♥Minanoʚ໒꒱· ﾟ 🎤💐@初日物販参戦',
-      user_account: 'Mi_n_a_n_o',
-      tweet_count: 1
+      userName: '♥Minanoʚ໒꒱· ﾟ 🎤💐@初日物販参戦',
+      userAccount: 'Mi_n_a_n_o',
+      tweetCount: 1
     },
     {
-      user_name: 'usk@DC中心垢&絵垢',
-      user_account: 'zer0moon',
-      tweet_count: 1
+      userName: 'usk@DC中心垢&絵垢',
+      userAccount: 'zer0moon',
+      tweetCount: 1
     },
     {
-      user_name: '十点 ザワ一般',
-      user_account: 'ji_ten',
-      tweet_count: 1
+      userName: '十点 ザワ一般',
+      userAccount: 'ji_ten',
+      tweetCount: 1
     },
     {
-      user_name: 'あんず@コナン垢',
-      user_account: 'conankidamuroai',
-      tweet_count: 1
+      userName: 'あんず@コナン垢',
+      userAccount: 'conankidamuroai',
+      tweetCount: 1
     },
     {
-      user_name: 'あや*ﾟ',
-      user_account: 'mhmh3866',
-      tweet_count: 1
+      userName: 'あや*ﾟ',
+      userAccount: 'mhmh3866',
+      tweetCount: 1
     },
     {
-      user_name: '白蓮会館伊藤道場',
-      user_account: 'ito_dojo',
-      tweet_count: 1
+      userName: '白蓮会館伊藤道場',
+      userAccount: 'ito_dojo',
+      tweetCount: 1
     },
     {
-      user_name: '幸村ゆん',
-      user_account: 'yun_youh',
-      tweet_count: 1
+      userName: '幸村ゆん',
+      userAccount: 'yun_youh',
+      tweetCount: 1
     },
     {
-      user_name: 'エビ',
-      user_account: 'ebimnc',
-      tweet_count: 1
+      userName: 'エビ',
+      userAccount: 'ebimnc',
+      tweetCount: 1
     },
     {
-      user_name: '十六夜@語彙力ゼロ,安室さん大好きまったりFGOAC  人狼 エマ',
-      user_account: 'HHf2PUTwfzEzkmp',
-      tweet_count: 1
+      userName: '十六夜@語彙力ゼロ,安室さん大好きまったりFGOAC  人狼 エマ',
+      userAccount: 'HHf2PUTwfzEzkmp',
+      tweetCount: 1
     },
     {
-      user_name: '紫輝@コンパスフェス行くぞぉ',
-      user_account: 'y9JUHViBx4qDC6M',
-      tweet_count: 1
+      userName: '紫輝@コンパスフェス行くぞぉ',
+      userAccount: 'y9JUHViBx4qDC6M',
+      tweetCount: 1
     },
     {
-      user_name: 'アサマチ',
-      user_account: 'asmc26',
-      tweet_count: 1
+      userName: 'アサマチ',
+      userAccount: 'asmc26',
+      tweetCount: 1
     },
     {
-      user_name: 'るるた',
-      user_account: 'ruta_mel',
-      tweet_count: 1
+      userName: 'るるた',
+      userAccount: 'ruta_mel',
+      tweetCount: 1
     },
     {
-      user_name: 'きっちゃん 低浮上',
-      user_account: 'conan8499',
-      tweet_count: 1
+      userName: 'きっちゃん 低浮上',
+      userAccount: 'conan8499',
+      tweetCount: 1
     },
     {
-      user_name: '@39🌱前厄🌱',
-      user_account: 'blackmoonxmr99',
-      tweet_count: 1
+      userName: '@39🌱前厄🌱',
+      userAccount: 'blackmoonxmr99',
+      tweetCount: 1
     },
     {
-      user_name: '基本なんでも推す狂歌',
-      user_account: 'NandemoosuKyoka',
-      tweet_count: 1
+      userName: '基本なんでも推す狂歌',
+      userAccount: 'NandemoosuKyoka',
+      tweetCount: 1
     },
     {
-      user_name: 'rain',
-      user_account: 'rain66736211',
-      tweet_count: 1
+      userName: 'rain',
+      userAccount: 'rain66736211',
+      tweetCount: 1
     },
     {
-      user_name: 'MOS',
-      user_account: 'trignaltoriniku',
-      tweet_count: 1
+      userName: 'MOS',
+      userAccount: 'trignaltoriniku',
+      tweetCount: 1
     },
     {
-      user_name: '藤吉',
-      user_account: 'over_a_Lycoris',
-      tweet_count: 1
+      userName: '藤吉',
+      userAccount: 'over_a_Lycoris',
+      tweetCount: 1
     },
     {
-      user_name: 'Ag',
-      user_account: 'twteje',
-      tweet_count: 1
+      userName: 'Ag',
+      userAccount: 'twteje',
+      tweetCount: 1
     },
     {
-      user_name: '必殺 310・サーガ',
-      user_account: 'f1stI8oT7dYUmck',
-      tweet_count: 1
+      userName: '必殺 310・サーガ',
+      userAccount: 'f1stI8oT7dYUmck',
+      tweetCount: 1
     },
     {
-      user_name: '街のナゲット職人',
-      user_account: 'nuggetsyokunin',
-      tweet_count: 1
+      userName: '街のナゲット職人',
+      userAccount: 'nuggetsyokunin',
+      tweetCount: 1
     },
     {
-      user_name: 'からころ🐾DD18w',
-      user_account: 'karankoron',
-      tweet_count: 1
+      userName: 'からころ🐾DD18w',
+      userAccount: 'karankoron',
+      tweetCount: 1
     },
     {
-      user_name: 'ももち0310',
-      user_account: 'MOCHImochi1350',
-      tweet_count: 1
+      userName: 'ももち0310',
+      userAccount: 'MOCHImochi1350',
+      tweetCount: 1
     },
     {
-      user_name: 'だーはら',
-      user_account: 'Johncena0322',
-      tweet_count: 1
+      userName: 'だーはら',
+      userAccount: 'Johncena0322',
+      tweetCount: 1
     },
     {
-      user_name: 'たんぽぽ@審神者',
-      user_account: 'dandan_de_lion',
-      tweet_count: 1
+      userName: 'たんぽぽ@審神者',
+      userAccount: 'dandan_de_lion',
+      tweetCount: 1
     },
     {
-      user_name: 'ひらあか',
-      user_account: 'Yasu_Aka_56',
-      tweet_count: 1
+      userName: 'ひらあか',
+      userAccount: 'Yasu_Aka_56',
+      tweetCount: 1
     },
     {
-      user_name: '長雨',
-      user_account: 'long_rain',
-      tweet_count: 1
+      userName: '長雨',
+      userAccount: 'long_rain',
+      tweetCount: 1
     },
     {
-      user_name: 'ブルーバード',
-      user_account: 'TAKOYAKI171118',
-      tweet_count: 1
+      userName: 'ブルーバード',
+      userAccount: 'TAKOYAKI171118',
+      tweetCount: 1
     },
     {
-      user_name: '音也くんに感謝！☆夢未希望☆',
-      user_account: 'Yuki12031203',
-      tweet_count: 1
+      userName: '音也くんに感謝！☆夢未希望☆',
+      userAccount: 'Yuki12031203',
+      tweetCount: 1
     },
     {
-      user_name: '哀輝',
-      user_account: 'bakuresturanbu',
-      tweet_count: 1
+      userName: '哀輝',
+      userAccount: 'bakuresturanbu',
+      tweetCount: 1
     },
     {
-      user_name: 'ハナ',
-      user_account: 'hnti7078',
-      tweet_count: 1
+      userName: 'ハナ',
+      userAccount: 'hnti7078',
+      tweetCount: 1
     },
     {
-      user_name: '厚揚',
-      user_account: 'FvBcGpBGFLMj8Hv',
-      tweet_count: 1
+      userName: '厚揚',
+      userAccount: 'FvBcGpBGFLMj8Hv',
+      tweetCount: 1
     },
     {
-      user_name: 'あかつき',
-      user_account: 'amam_45saikou',
-      tweet_count: 1
+      userName: 'あかつき',
+      userAccount: 'amam_45saikou',
+      tweetCount: 1
     },
     {
-      user_name: 'リモン🍊',
-      user_account: 'TxvtHh5',
-      tweet_count: 1
+      userName: 'リモン🍊',
+      userAccount: 'TxvtHh5',
+      tweetCount: 1
     },
     {
-      user_name: 'ふくろう',
-      user_account: '0mhsaQ77SOahlyy',
-      tweet_count: 1
+      userName: 'ふくろう',
+      userAccount: '0mhsaQ77SOahlyy',
+      tweetCount: 1
     },
     {
-      user_name: 'くゆう:)Aqours5th両日',
-      user_account: 'ta2yoyo',
-      tweet_count: 1
+      userName: 'くゆう:)Aqours5th両日',
+      userAccount: 'ta2yoyo',
+      tweetCount: 1
     },
     {
-      user_name: 'ツキタケ',
-      user_account: 'fuku0000very',
-      tweet_count: 1
+      userName: 'ツキタケ',
+      userAccount: 'fuku0000very',
+      tweetCount: 1
     },
     {
-      user_name: 'まつも',
-      user_account: 'xamc0amx',
-      tweet_count: 1
+      userName: 'まつも',
+      userAccount: 'xamc0amx',
+      tweetCount: 1
     },
     {
-      user_name: '朝里@趣味のために仕事頑張る',
-      user_account: 'salty_road',
-      tweet_count: 1
+      userName: '朝里@趣味のために仕事頑張る',
+      userAccount: 'salty_road',
+      tweetCount: 1
     },
     {
-      user_name: 'おさつのいも🍠',
-      user_account: '1201_7310',
-      tweet_count: 1
+      userName: 'おさつのいも🍠',
+      userAccount: '1201_7310',
+      tweetCount: 1
     },
     {
-      user_name: '羅徵禾',
-      user_account: 'smiling2bear29',
-      tweet_count: 1
+      userName: '羅徵禾',
+      userAccount: 'smiling2bear29',
+      tweetCount: 1
     },
     {
-      user_name: 'きょー',
-      user_account: 'lovemschildren_',
-      tweet_count: 1
+      userName: 'きょー',
+      userAccount: 'lovemschildren_',
+      tweetCount: 1
     },
     {
-      user_name: 'ナガ太🍀🎀🤛',
-      user_account: 'InfiTvxq',
-      tweet_count: 1
+      userName: 'ナガ太🍀🎀🤛',
+      userAccount: 'InfiTvxq',
+      tweetCount: 1
     },
     {
-      user_name: 'はんな@執行済み',
-      user_account: 'hanna_Zero',
-      tweet_count: 1
+      userName: 'はんな@執行済み',
+      userAccount: 'hanna_Zero',
+      tweetCount: 1
     },
     {
-      user_name: '零',
-      user_account: 'lerammoned',
-      tweet_count: 1
+      userName: '零',
+      userAccount: 'lerammoned',
+      tweetCount: 1
     },
     {
-      user_name: 'えぬこ@26日渋谷マルイとフードファイト',
-      user_account: 'enu_8',
-      tweet_count: 1
+      userName: 'えぬこ@26日渋谷マルイとフードファイト',
+      userAccount: 'enu_8',
+      tweetCount: 1
     },
     {
-      user_name: 'ぽっ@関西',
-      user_account: 'syuppoco',
-      tweet_count: 1
+      userName: 'ぽっ@関西',
+      userAccount: 'syuppoco',
+      tweetCount: 1
     },
     {
-      user_name: '📎black_black_cat',
-      user_account: '0909_black_cat',
-      tweet_count: 1
+      userName: '📎black_black_cat',
+      userAccount: '0909_black_cat',
+      tweetCount: 1
     },
     {
-      user_name: 'non♡mi🇯🇵',
-      user_account: 'Nmi15Non',
-      tweet_count: 1
+      userName: 'non♡mi🇯🇵',
+      userAccount: 'Nmi15Non',
+      tweetCount: 1
     },
     {
-      user_name: '月島波留日(つっしー)',
-      user_account: 'Gvjl_Bpjk_zfck7',
-      tweet_count: 1
+      userName: '月島波留日(つっしー)',
+      userAccount: 'Gvjl_Bpjk_zfck7',
+      tweetCount: 1
     },
     {
-      user_name: 'おぼず',
-      user_account: 'oboz0602',
-      tweet_count: 1
+      userName: 'おぼず',
+      userAccount: 'oboz0602',
+      tweetCount: 1
     },
     {
-      user_name: 'あきの紅葉（無言フォローでタグお迎え中）',
-      user_account: 'Momiji_10046',
-      tweet_count: 1
+      userName: 'あきの紅葉（無言フォローでタグお迎え中）',
+      userAccount: 'Momiji_10046',
+      tweetCount: 1
     },
     {
-      user_name: 'とっとこあふぇ太郎@TRPGリプレイ動画にはまってます！',
-      user_account: 'AffettiSurface',
-      tweet_count: 1
+      userName: 'とっとこあふぇ太郎@TRPGリプレイ動画にはまってます！',
+      userAccount: 'AffettiSurface',
+      tweetCount: 1
     }
   ]
 };

--- a/src/views/AnalysisResult.vue
+++ b/src/views/AnalysisResult.vue
@@ -131,36 +131,36 @@ export default Vue.extend({
         .get(endpoint, { timeout: 5000 })
         .then(response => {
           this.image = response.data.image;
-          this.startDate = response.data.analysis_start_date;
-          this.endDate = response.data.analysis_end_date;
-          this.analysisWord = response.data.analysis_word;
-          this.tweetCount = response.data.tweet_count;
-          this.favoriteCount = response.data.favorite_count;
-          this.userCount = response.data.user_count;
-          this.retweetCount = response.data.retweet_count;
-          this.tableUserRank = response.data.user_ranking.map((val: any, index: any) => {
+          this.startDate = response.data.analysisStartDate;
+          this.endDate = response.data.analysisEndDate;
+          this.analysisWord = response.data.analysisWord;
+          this.tweetCount = response.data.tweetCount;
+          this.favoriteCount = response.data.favoriteCount;
+          this.userCount = response.data.userCount;
+          this.retweetCount = response.data.retweetCount;
+          this.tableUserRank = response.data.userRanking.map((val: any, index: any) => {
             return {
               no: index,
-              name: `${val.user_name}(@${val.user_account})`,
-              tweet: `${val.tweet_count}ツイート`
+              name: `${val.userName}(@${val.userAccount})`,
+              tweet: `${val.tweetCount}ツイート`
             };
           });
         })
         .catch(error => {
           // テストデータを反映
           this.image = ANALYSIS_RESULT.image;
-          this.startDate = ANALYSIS_RESULT.analysis_start_date;
-          this.endDate = ANALYSIS_RESULT.analysis_end_date;
-          this.analysisWord = ANALYSIS_RESULT.analysis_word;
-          this.tweetCount = ANALYSIS_RESULT.tweet_count;
-          this.favoriteCount = ANALYSIS_RESULT.favorite_count;
-          this.userCount = ANALYSIS_RESULT.user_count;
-          this.retweetCount = ANALYSIS_RESULT.retweet_count;
-          this.tableUserRank = ANALYSIS_RESULT.user_ranking.map((val: any, index: any) => {
+          this.startDate = ANALYSIS_RESULT.analysisStartDate;
+          this.endDate = ANALYSIS_RESULT.analysisEndDate;
+          this.analysisWord = ANALYSIS_RESULT.analysisWord;
+          this.tweetCount = ANALYSIS_RESULT.tweetCount;
+          this.favoriteCount = ANALYSIS_RESULT.favoriteCount;
+          this.userCount = ANALYSIS_RESULT.userCount;
+          this.retweetCount = ANALYSIS_RESULT.retweetCount;
+          this.tableUserRank = ANALYSIS_RESULT.userRanking.map((val: any, index: any) => {
             return {
               no: index,
-              name: `${val.user_name}(@${val.user_account})`,
-              tweet: `${val.tweet_count}ツイート`
+              name: `${val.userName}(@${val.userAccount})`,
+              tweet: `${val.tweetCount}ツイート`
             };
           });
           (this as any).$notify.warning({


### PR DESCRIPTION
# 対応内容
#84 の内容を修正しました。

# 確認方法
backend を最新にして解析結果画面を表示。API のレスポンスがキャメルケースでも問題なく表示されること。
![p](https://user-images.githubusercontent.com/10674169/57117854-0f43bf00-6d9a-11e9-9739-2d4e634278b5.png)

# クローズするissue
close #84

# このタスクで発生したissue
なし

# その他
mockdata の方も修正しておきました。